### PR TITLE
refactor #40: 폰트 경로 에러 수정

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -6,19 +6,19 @@ $desktop-screen: 'screen and (min-width: 1200px)';
 // font
 @font-face {
   font-family: 'pretendard';
-  src: url('../public/Pretendard-Regular.ttf');
+  src: url('/Pretendard-Regular.ttf');
 }
 @font-face {
   font-family: 'Noto-Sans';
-  src: url('../public/NotoSansKR-Regular.ttf');
+  src: url('/NotoSansKR-Regular.ttf');
 }
 @font-face {
   font-family: 'NanumMyengjo';
-  src: url('../public/NanumMyengjo-Regular.ttf');
+  src: url('/NanumMyengjo-Regular.ttf');
 }
 @font-face {
   font-family: 'NanumSonPyeonJiCe';
-  src: url('../public/NanumSonPyeonJiCe-Regular.ttf');
+  src: url('/NanumSonPyeonJiCe-Regular.ttf');
 }
 
 // font sizes


### PR DESCRIPTION
#40 

# 변경 사항
- Vite가 /public 디렉토리 내의 파일들을 배포 시 루트 경로(/)로 매핑하기 때문에, /public을 포함한 경로로 접근하면 안 되고, /Pretendard-Regular.ttf와 같은 루트 경로로 접근해야 합니다.

---
에러 메세지 발견
![before](https://github.com/6Team-Project/MessageBloom/assets/97877328/7fd58bb4-0665-4ce0-9e9a-22a9a3e58d00)

---
수정 후 에러 메세지 사라짐
![after](https://github.com/6Team-Project/MessageBloom/assets/97877328/1bac45e6-9a6e-4bff-84e1-3d88b9827b60)

