### PR TITLE
refactor/#131/에디터 툴바 제거

### DIFF
--- a/src/components/post-id-message-page/ContentTextarea.jsx
+++ b/src/components/post-id-message-page/ContentTextarea.jsx
@@ -49,7 +49,7 @@ function ContentTextarea({ setError }, contentTextareaRef) {
       </label>
       <Editor
         id='textarea'
-        height='400px'
+        minHeight='400px'
         initialEditType='wysiwyg'
         placeholder='좋은 추억이나 감사의 메세지를 작성해 주세요!'
         ref={ref}

--- a/src/components/post-id-message-page/ContentTextarea.scss
+++ b/src/components/post-id-message-page/ContentTextarea.scss
@@ -1,22 +1,16 @@
 @import '../../styles/variables';
 
-.message-form__text-area {
-  width: 100%;
-  height: 308px;
-  padding: 16px 16px;
-  border-radius: 8px;
-  border: 1px solid $gray300;
-  resize: none;
-  @include font-style(16, Regular);
-  color: $gray800;
-}
-
-.message-form__text-area::placeholder {
-  @include font-style(14, Regular);
-  color: $gray400;
-}
-
 .toastui-editor-defaultUI .ProseMirror {
   padding: 18px 25px;
   @include font-style(16, Regular);
+}
+
+.toastui-editor-toolbar {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .placeholder {
+    font-size: 14px;
+  }
 }

--- a/src/components/post-page/ColorPicker.scss
+++ b/src/components/post-page/ColorPicker.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables', '../../styles/variables';
+@import '../../styles/variables';
 
 @mixin flex-center {
   display: flex;


### PR DESCRIPTION
#131 

# 변경 사항
- 툴바의 기능들을 사용하지 않기 때문에 display: none 처리
- 에디터는 줄바꿈 정보를 처리하는 기능만 사용하고 있음
- 반응형 디자인 추가 : placeholder의 크기 조절
---
![image](https://github.com/6Team-Project/MessageBloom/assets/97877328/becd42e0-3591-403a-962a-fed4129649d2)
