### PR TITLE
refactor #136: 리렌더링 해결

### DIFF
--- a/src/components/commons/mouseTracker/index.jsx
+++ b/src/components/commons/mouseTracker/index.jsx
@@ -1,28 +1,21 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { throttle } from 'lodash';
 
-// alpha: 0 ~ 1의 숫자, 0은 이전 마우스 위치, 1은 현재 마우스 위치, 숫자가 작을수록 따라오는 이미지가 느려진다
 export default function MouseTracker({ text, imgUrl, children, alpha = 1 }) {
-  // 초기값을 대상 요소의 크기 기준으로 배치하면 기본 디자인 중 일부가 갑자기 움직이는 반전을 기대할 수 있을 것 같다
-  const [prevMouse, setPrevMouse] = useState({ x: 210, y: 10 });
   const targetRef = useRef(null);
+  const imageRef = useRef(null);
 
-  // lerp(): 선간 보간법 계산 함수, 이전 위치와 현재 위치의 중간 위치를 계산
-  // 이 함수를 사용한 장점: 부드러운 움직임, 약간 떨어뜨려놓아서 마우스를 가리지 않음
   const lerp = (start, end, alpha) => {
     return start * (1 - alpha) + end * alpha;
   };
 
   const handleMove = throttle((e) => {
-    //현재 마우스 위치
     const rect = targetRef.current.getBoundingClientRect();
-    const x = e.clientX - rect.left; // 요소 내의 상대 X 좌표
-    const y = e.clientY - rect.top; // 요소 내의 상대 Y 좌표
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
 
-    const newX = lerp(prevMouse.x, x, alpha);
-    const newY = lerp(prevMouse.y, y, alpha);
-
-    setPrevMouse({ x: newX, y: newY });
+    imageRef.current.style.left = `${lerp(parseFloat(imageRef.current.style.left), x, alpha)}px`;
+    imageRef.current.style.top = `${lerp(parseFloat(imageRef.current.style.top), y, alpha)}px`;
   }, 100);
 
   useEffect(() => {
@@ -31,23 +24,27 @@ export default function MouseTracker({ text, imgUrl, children, alpha = 1 }) {
 
     return () => {
       targetEl.removeEventListener('mousemove', handleMove);
-      handleMove.cancel(); //throttle를 구현한 lodash의 메서드
+      handleMove.cancel();
     };
   }, []);
-
-  const trackerStyles = {
-    position: 'absolute',
-    left: `${prevMouse.x}px`,
-    top: `${prevMouse.y}px`,
-    pointerEvents: 'none',
-    zIndex: 9999,
-    backgroundImage: `url(${imgUrl})`,
-  };
 
   return (
     <div style={{ position: 'relative', width: '100%' }} ref={targetRef}>
       {children}
-      <div style={trackerStyles}>{text}</div>
+      <div
+        className='track-Img'
+        ref={imageRef}
+        style={{
+          position: 'absolute',
+          pointerEvents: 'none',
+          zIndex: 9999,
+          left: 0,
+          top: -100,
+          opacity: 0.7,
+          backgroundImage: `url(${imgUrl})`,
+        }}>
+        {text}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
#136 

# 변경 사항
- 드디어 리액트에서도 리렌더링 없이 움직이는 요소 적용에 성공
- useRef를 사용해서 DOM을 직접 업데이트하는 방법
- 리액트의 상태값을 변경하지 않으므로 리액트 라이프사이클과 별도로 동작함
- scss를 사용해서 스타일을 적용하면 변경되는 left, top이 적용되지 않아서 기본값을 화면 밖으로 내보냄

---
![마우스트래커 개선](https://github.com/6Team-Project/MessageBloom/assets/97877328/1f60d26e-45c2-4183-940c-02d151031d3f)
