### PR TITLE
refactor #162: 마우스트래커 전체 적용

### DIFF
--- a/src/components/commons/mouseTracker/index.jsx
+++ b/src/components/commons/mouseTracker/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { throttle } from 'lodash';
 
-export default function MouseTracker({ text, imgUrl, children, alpha = 1 }) {
+export default function MouseTracker({ text, imgUrl, children, alpha = 0.8 }) {
   const targetRef = useRef(null);
   const imageRef = useRef(null);
 
@@ -40,7 +40,6 @@ export default function MouseTracker({ text, imgUrl, children, alpha = 1 }) {
           zIndex: 9999,
           left: 0,
           top: -100,
-          opacity: 0.7,
           backgroundImage: `url(${imgUrl})`,
         }}>
         {text}

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -3,7 +3,6 @@ import { Link, useLocation } from 'react-router-dom';
 import './Header.scss';
 import logo from '../../assets/logo/ic_flower_RemoveBg.svg';
 import LetterAnimation from '../animation/LetterAnimation';
-import MouseTracker from '../commons/mouseTracker';
 
 export default function Header() {
   const location = useLocation();
@@ -16,14 +15,12 @@ export default function Header() {
     <header className={`header`}>
       <div className='header-container'>
         <Link to='/' aria-label='홈으로 이동'>
-          <MouseTracker text='💌'>
-            <div className='header-container__logo'>
-              <picture className='header-container__logo__img-wrap'>
-                <img src={logo} alt='로고 아이콘' className='header-container__logo__img' />
-              </picture>
-              <span className='header-container__logo__title'> Message Bloom</span>
-            </div>
-          </MouseTracker>
+          <div className='header-container__logo'>
+            <picture className='header-container__logo__img-wrap'>
+              <img src={logo} alt='로고 아이콘' className='header-container__logo__img' />
+            </picture>
+            <span className='header-container__logo__title'> Message Bloom</span>
+          </div>
         </Link>
 
         <div className='header-container__right-side'>

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Header from '../components/header';
+import MouseTracker from '../components/commons/mouseTracker';
 
 const Layout = () => {
   return (
     <>
-      <Header />
-      <Outlet />
+      <MouseTracker text='💌'>
+        <Header />
+        <Outlet />
+      </MouseTracker>
     </>
   );
 };


### PR DESCRIPTION
#162 

# 변경 사항
- 헤더의 로고를 감싸던 마우스트래커 제거
- 레이아웃의 헤더와 outlet을 감싸는 마우스트래커 추가
---
![마우스트래커최종](https://github.com/6Team-Project/MessageBloom/assets/97877328/abefaef2-01af-4727-a1e8-1b63c3772c33)
